### PR TITLE
Add ManagedLeaderLatchCreator

### DIFF
--- a/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreator.java
+++ b/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreator.java
@@ -1,0 +1,270 @@
+package org.kiwiproject.curator.leader;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import io.dropwizard.setup.Environment;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.kiwiproject.curator.leader.exception.ManagedLeaderLatchException;
+import org.kiwiproject.curator.leader.health.ManagedLeaderLatchHealthCheck;
+import org.kiwiproject.curator.leader.resource.GotLeaderLatchResource;
+import org.kiwiproject.curator.leader.resource.LeaderResource;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Entry point to initialize {@link ManagedLeaderLatch}, which wraps an Apache Curator
+ * {@link org.apache.curator.framework.recipes.leader.LeaderLatch} and allows for easy determination
+ * whether a JVM process is the leader in a group of JVMs connected to a ZooKeeper cluster.
+ * <p>
+ * The {@link ManagedLeaderLatch} created by this class will be started immediately, but is a Dropwizard
+ * {@link io.dropwizard.lifecycle.Managed} so that it will be stopped when the Dropwizard service shuts down.
+ * <p>
+ * In addition, by default a {@link ManagedLeaderLatchHealthCheck} is registered with Dropwizard. Two REST resources
+ * are registered, {@link GotLeaderLatchResource} and {@link LeaderResource}.
+ */
+@Slf4j
+public class ManagedLeaderLatchCreator {
+
+    // Initialized at construction
+    private final CuratorFramework client;
+    private final Environment environment;
+    private final ServiceDescriptor serviceDescriptor;
+    private final List<LeaderLatchListener> listeners;
+
+    // Initialized via instance start() method so cannot be final (unless we used Kotlin and lateinit)
+    private ManagedLeaderLatch leaderLatch;
+    private boolean addHealthCheck;
+    private ManagedLeaderLatchHealthCheck healthCheck;
+    private boolean addResources;
+
+    private ManagedLeaderLatchCreator(CuratorFramework client,
+                                      Environment environment,
+                                      ServiceDescriptor serviceDescriptor,
+                                      List<LeaderLatchListener> listeners) {
+
+        this.client = requireNotNull(client);
+        checkState(client.getState() == CuratorFrameworkState.STARTED, "CuratorFramework must be started");
+
+        this.environment = requireNotNull(environment);
+        this.serviceDescriptor = requireNotNull(serviceDescriptor);
+        this.listeners = requireNotNull(listeners);
+        this.addHealthCheck = true;
+        this.addResources = true;
+    }
+
+    /**
+     * Static factory method to create a {@link ManagedLeaderLatchCreator}.
+     * <p>
+     * Use this method when you want to perform additional configuration before starting the leader latch.
+     * <p>
+     * You will need to call {@link #start()} on the returned instance in order to start the
+     * {@link ManagedLeaderLatch}.
+     *
+     * @param client            the Curator client
+     * @param environment       the Dropwizard environment
+     * @param serviceDescriptor service metadata
+     * @param listeners         optional listeners
+     * @return a new instance
+     * @throws IllegalStateException if the {@code client} is not started, or any required arguments are null
+     */
+    public static ManagedLeaderLatchCreator from(CuratorFramework client,
+                                                 Environment environment,
+                                                 ServiceDescriptor serviceDescriptor,
+                                                 LeaderLatchListener... listeners) {
+
+        // The list of listeners passed to the constructor must be mutable or else exceptions will be thrown if
+        // addLeaderLatchListener is called subsequently (since it adds to the existing list).
+
+        return new ManagedLeaderLatchCreator(client, environment, serviceDescriptor, newArrayList(listeners));
+    }
+
+    /**
+     * If the only thing you want is a {@link ManagedLeaderLatch} and you want the standard options (a health
+     * check and JAX-RS REST resources) and you do not need references to them, use this method to create and
+     * start a latch.
+     * <p>
+     * Otherwise use {@link #start(CuratorFramework, Environment, ServiceDescriptor, LeaderLatchListener...)}.
+     *
+     * @param client            the Curator client
+     * @param environment       the Dropwizard environment
+     * @param serviceDescriptor the service information from the registry
+     * @param listeners         optional listeners
+     * @return a started {@link ManagedLeaderLatch}
+     * @throws IllegalStateException if the {@code client} is not started, or any required arguments are null
+     * @see #start(CuratorFramework, Environment, ServiceDescriptor, LeaderLatchListener...)
+     */
+    public static ManagedLeaderLatch startLeaderLatch(CuratorFramework client,
+                                                      Environment environment,
+                                                      ServiceDescriptor serviceDescriptor,
+                                                      LeaderLatchListener... listeners) {
+
+        var leaderLatchCreator = start(client, environment, serviceDescriptor, listeners);
+
+        return leaderLatchCreator.getLeaderLatch();
+    }
+
+    /**
+     * If you want a {@link ManagedLeaderLatch} and you want the standard options (a health
+     * check and JAX-RS REST resources) and you might need references to them, use this method to create and
+     * start a latch.
+     * <p>
+     * The returned {@link ManagedLeaderLatchCreator} can be used to then obtain the {@link ManagedLeaderLatch}
+     * as well as the health check and listeners.
+     *
+     * @param client      the Curator client
+     * @param environment the Dropwizard environment
+     * @param serviceInfo the service information from the registry
+     * @param listeners   optional listeners
+     * @return a {@link ManagedLeaderLatchCreator} with a started {@link ManagedLeaderLatch}
+     * @throws IllegalStateException if the {@code client} is not started, or any required arguments are null
+     */
+    public static ManagedLeaderLatchCreator start(CuratorFramework client,
+                                                  Environment environment,
+                                                  ServiceDescriptor serviceInfo,
+                                                  LeaderLatchListener... listeners) {
+
+        return from(client, environment, serviceInfo, listeners).start();
+    }
+
+    /**
+     * Configures <em>without</em> a health check.
+     * <p>
+     * Use only when constructing a new {@link ManagedLeaderLatchCreator}.
+     *
+     * @return this instance, for method chaining
+     */
+    public ManagedLeaderLatchCreator withoutHealthCheck() {
+        addHealthCheck = false;
+        return this;
+    }
+
+    /**
+     * Configures <em>without</em> REST resources to check for leadership and if a leader latch is present.
+     * <p>
+     * Use only when constructing a new {@link ManagedLeaderLatchCreator}.
+     *
+     * @return this instance, for method chaining
+     */
+    public ManagedLeaderLatchCreator withoutResources() {
+        addResources = false;
+        return this;
+    }
+
+    /**
+     * Adds the specified {@link LeaderLatchListener}.
+     * <p>
+     * Use only when constructing a new {@link ManagedLeaderLatchCreator}.
+     *
+     * @return this instance, for method chaining
+     */
+    public ManagedLeaderLatchCreator addLeaderLatchListener(LeaderLatchListener listener) {
+        listeners.add(listener);
+        return this;
+    }
+
+    /**
+     * Starts the leader latch, performing the following actions:
+     * <ul>
+     * <li>
+     *     Creates a new {@link ManagedLeaderLatch}, starts it, and tells the Dropwizard lifecycle to manage (stop) it
+     * </li>
+     * <li>
+     *     Creates and registers a {@link ManagedLeaderLatchHealthCheck} unless explicitly disabled via
+     *     {@link #withoutHealthCheck()}
+     * </li>
+     * <li>
+     *     Creates and registers the JAX-RS REST endpoints unless explicitly disabled via {@link #withoutResources()}
+     * </li>
+     * </ul>
+     * <p>
+     * Note that once this method is called, nothing about the {@link ManagedLeaderLatch} can be changed, and calls
+     * to other instance methods (e.g. addLeaderLatchListener) will have no effect. Similarly, calling this method
+     * more than once is considered unexpected behavior, and we will simply return the existing instance without
+     * taking any other actions.
+     *
+     * @return this instance, from which you can then retrieve the (started) {@link ManagedLeaderLatch}
+     * @throws ManagedLeaderLatchException if an error occurs starting the latch
+     */
+    public ManagedLeaderLatchCreator start() {
+        if (nonNull(leaderLatch)) {
+            LOG.warn("start() has already been called. Ignoring this invocation.");
+            return this;
+        }
+
+        var listenerArray = listeners.toArray(new LeaderLatchListener[0]);
+        leaderLatch = new ManagedLeaderLatch(client, serviceDescriptor, listenerArray);
+        environment.lifecycle().manage(leaderLatch);
+        startLatchOrThrow();
+        addHealthCheckIfConfigured();
+        addResourcesIfConfigured();
+
+        return this;
+    }
+
+    private void startLatchOrThrow() {
+        try {
+            leaderLatch.start();
+        } catch (Exception e) {
+            throw new ManagedLeaderLatchException("Error starting leader latch", e);
+        }
+    }
+
+    private void addHealthCheckIfConfigured() {
+        if (addHealthCheck) {
+            healthCheck = new ManagedLeaderLatchHealthCheck(leaderLatch);
+            environment.healthChecks().register("leaderLatch", healthCheck);
+        }
+    }
+
+    private void addResourcesIfConfigured() {
+        if (addResources) {
+            environment.jersey().register(new GotLeaderLatchResource());
+            environment.jersey().register(new LeaderResource(leaderLatch));
+        }
+    }
+
+    /**
+     * Returns the {@link ManagedLeaderLatch} created after {@link #start()} has been called.
+     *
+     * @return the leader latch
+     * @throws IllegalStateException if called but the latch has not been started yet
+     */
+    public ManagedLeaderLatch getLeaderLatch() {
+        validateStarted();
+        return leaderLatch;
+    }
+
+    /**
+     * Returns the health check (if registered) after {@link #start()} has been called.
+     *
+     * @return the registered health check
+     * @throws IllegalStateException if called but the latch has not been started yet
+     */
+    public Optional<ManagedLeaderLatchHealthCheck> getHealthCheck() {
+        validateStarted();
+        return Optional.ofNullable(healthCheck);
+    }
+
+    /**
+     * Returns a list containing all registered {@link LeaderLatchListener}s after {@link #start()} has been called.
+     *
+     * @return any registered {@link LeaderLatchListener}s
+     * @throws IllegalStateException if called but the latch has not been started yet
+     * @implNote The returned list is an unmodifiable list containing the registered listeners
+     */
+    public List<LeaderLatchListener> getListeners() {
+        validateStarted();
+        return List.copyOf(listeners);
+    }
+
+    private void validateStarted() {
+        checkState(nonNull(leaderLatch), "Leader latch is not started; call start() first");
+    }
+}

--- a/src/main/java/org/kiwiproject/curator/leader/ServiceDescriptor.java
+++ b/src/main/java/org/kiwiproject/curator/leader/ServiceDescriptor.java
@@ -1,0 +1,13 @@
+package org.kiwiproject.curator.leader;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ServiceDescriptor {
+    String name;
+    String version;
+    String hostname;
+    int port;
+}

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
@@ -1,0 +1,293 @@
+package org.kiwiproject.curator.leader;
+
+import static java.util.Objects.nonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.collect.KiwiLists.second;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.curator.leader.health.ManagedLeaderLatchHealthCheck;
+import org.kiwiproject.curator.leader.resource.GotLeaderLatchResource;
+import org.kiwiproject.curator.leader.resource.LeaderResource;
+import org.kiwiproject.test.curator.CuratorTestingServerExtension;
+import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@DisplayName("ManagedLeaderLatchCreator")
+@ExtendWith(SoftAssertionsExtension.class)
+class ManagedLeaderLatchCreatorTest {
+
+    @RegisterExtension
+    static final CuratorTestingServerExtension ZK_TEST_SERVER = new CuratorTestingServerExtension();
+
+    private CuratorFramework client;
+    private Environment environment;
+    private JerseyEnvironment jersey;
+    private LifecycleEnvironment lifecycle;
+    private HealthCheckRegistry healthCheckRegistry;
+    private ServiceDescriptor serviceDescriptor;
+
+    @BeforeEach
+    void setUp() {
+        client = ZK_TEST_SERVER.getClient();
+        var dropwizardMockitoContext = DropwizardMockitoMocks.mockDropwizard();
+        environment = dropwizardMockitoContext.environment();
+        jersey = dropwizardMockitoContext.jersey();
+        lifecycle = dropwizardMockitoContext.lifecycle();
+        healthCheckRegistry = dropwizardMockitoContext.healthChecks();
+        serviceDescriptor = ServiceDescriptor.builder()
+                .name("test-service")
+                .version("42.0.84")
+                .hostname("host42")
+                .port(8042)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        var rootPath = "/kiwi/leader-latch";
+        var stat = client.checkExists().forPath(rootPath);
+        if (nonNull(stat)) {
+            client.delete().deletingChildrenIfNeeded().forPath(rootPath);
+        }
+    }
+
+    @Test
+    void shouldThrowIllegalStateExceptions_FromGetMethods_WhenNotStarted(SoftAssertions softly) {
+        var latchCreator = ManagedLeaderLatchCreator.from(client, environment, serviceDescriptor);
+
+        softlyAssertIllegalStateExceptionThrownBy(softly, latchCreator::getLeaderLatch);
+        softlyAssertIllegalStateExceptionThrownBy(softly, latchCreator::getHealthCheck);
+        softlyAssertIllegalStateExceptionThrownBy(softly, latchCreator::getListeners);
+    }
+
+    private void softlyAssertIllegalStateExceptionThrownBy(SoftAssertions softly,
+                                                           ThrowableAssert.ThrowingCallable callable) {
+        softly.assertThatThrownBy(callable).isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldCreateAndManageLeaderLatch(SoftAssertions softly) {
+        var latchCreator = ManagedLeaderLatchCreator
+                .from(client, environment, serviceDescriptor)
+                .start();
+
+        assertThat(latchCreator.getLeaderLatch()).isNotNull();
+        softly.assertThat(latchCreator.getListeners()).isEmpty();
+
+        var managedCaptor = ArgumentCaptor.forClass(Managed.class);
+        verify(lifecycle).manage(managedCaptor.capture());
+        var capturedArgs = managedCaptor.getAllValues();
+        assertThat(capturedArgs).hasSize(1);
+
+        var managed = first(capturedArgs);
+        assertThat(managed).isExactlyInstanceOf(ManagedLeaderLatch.class);
+
+        var managedLeaderLatch = (ManagedLeaderLatch) managed;
+        softly.assertThat(managedLeaderLatch.getId())
+                .isEqualTo(ManagedLeaderLatch.leaderLatchId(serviceDescriptor));
+
+        softly.assertThat(managedLeaderLatch.getLatchPath())
+                .isEqualTo(ManagedLeaderLatch.leaderLatchPath(serviceDescriptor.getName()));
+
+        softly.assertThat(managedLeaderLatch.getLatchState())
+                .isEqualTo(LeaderLatch.State.STARTED);
+    }
+
+    @Test
+    void shouldIgnoreMultipleCallsToStart() {
+        var latchCreator = ManagedLeaderLatchCreator.from(client, environment, serviceDescriptor);
+
+        var latch1 = latchCreator.start();
+        var latch2 = latchCreator.start();
+        var latch3 = latchCreator.start();
+
+        assertThat(latch1)
+                .isSameAs(latch2)
+                .isSameAs(latch3);
+
+        verify(lifecycle).manage(any(Managed.class));
+        verify(jersey, times(2)).register(any(Object.class));
+        verify(healthCheckRegistry).register(anyString(), any());
+
+        verifyNoMoreInteractions(lifecycle, jersey, healthCheckRegistry);
+    }
+
+    @Test
+    void shouldRegisterListeners_InOrder_UsingVarargs() {
+        var noOpListener = new NoOpListener();
+        var latchCreator = ManagedLeaderLatchCreator
+                .from(client, environment, serviceDescriptor, noOpListener)
+                .start();
+
+        assertThat(latchCreator.getListeners()).hasSize(1);
+        assertThat(first(latchCreator.getListeners())).isSameAs(noOpListener);
+    }
+
+    @Test
+    void shouldRegisterListeners_InOrder_UsingAddMethod() {
+        var noOpListener = new NoOpListener();
+        var loggingListener = new SimpleLoggingListener();
+        var latchCreator = ManagedLeaderLatchCreator.from(client, environment, serviceDescriptor)
+                .addLeaderLatchListener(noOpListener)
+                .addLeaderLatchListener(loggingListener)
+                .start();
+
+        assertThat(latchCreator.getListeners()).hasSize(2);
+        assertThat(first(latchCreator.getListeners())).isSameAs(noOpListener);
+        assertThat(second(latchCreator.getListeners())).isSameAs(loggingListener);
+    }
+
+    @Test
+    void shouldReturnImmutableCopyOfListeners() {
+        var noOpListener = new NoOpListener();
+        var loggingListener = new SimpleLoggingListener();
+        var latchCreator = ManagedLeaderLatchCreator
+                .from(client, environment, serviceDescriptor, noOpListener, loggingListener)
+                .start();
+
+        var listeners = latchCreator.getListeners();
+
+        assertThatThrownBy(() -> listeners.add(loggingListener))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private static class NoOpListener implements LeaderLatchListener {
+        @Override
+        public void isLeader() {
+        }
+
+        @Override
+        public void notLeader() {
+        }
+    }
+
+    @Slf4j
+    private static class SimpleLoggingListener implements LeaderLatchListener {
+        @Override
+        public void isLeader() {
+            LOG.info("I lead");
+        }
+
+        @Override
+        public void notLeader() {
+            LOG.info("I follow");
+        }
+    }
+
+    @Test
+    void shouldRegisterHeathCheck_ByDefault() {
+        var latchCreator = ManagedLeaderLatchCreator.from(client, environment, serviceDescriptor).start();
+        assertThat(latchCreator.getHealthCheck()).isNotEmpty();
+
+        var healthCheck = latchCreator.getHealthCheck().orElseThrow(IllegalStateException::new);
+        verify(healthCheckRegistry).register("leaderLatch", healthCheck);
+    }
+
+    @Test
+    void shouldNotRegisterHeathCheck_IfDisabled() {
+        var latchCreator = ManagedLeaderLatchCreator.from(client, environment, serviceDescriptor)
+                .withoutHealthCheck()
+                .start();
+
+        assertThat(latchCreator.getHealthCheck()).isEmpty();
+        verifyNoInteractions(healthCheckRegistry);
+    }
+
+    @Test
+    void shouldRegisterResources_ByDefault() {
+        ManagedLeaderLatchCreator.from(client, environment, serviceDescriptor).start();
+
+        verify(jersey).register(isA(GotLeaderLatchResource.class));
+        verify(jersey).register(isA(LeaderResource.class));
+    }
+
+    @Test
+    void shouldNotRegisterResources_IfDisabled() {
+        ManagedLeaderLatchCreator.from(client, environment, serviceDescriptor)
+                .withoutResources()
+                .start();
+
+        verifyNoInteractions(jersey);
+    }
+
+    @Test
+    void shouldStartLeaderLatch_WithAllTheDefaultThings() {
+        var listener = new BecameLeaderListener();
+        var leaderLatch = ManagedLeaderLatchCreator.startLeaderLatch(client, environment, serviceDescriptor, listener);
+
+        verify(healthCheckRegistry).register(eq("leaderLatch"), isA(ManagedLeaderLatchHealthCheck.class));
+        verify(jersey).register(isA(GotLeaderLatchResource.class));
+        verify(jersey).register(isA(LeaderResource.class));
+
+        assertStartedAndBecameLeader(leaderLatch, listener);
+    }
+
+    @Test
+    void shouldStart_WithAllTheDefaultThings() {
+        var listener = new BecameLeaderListener();
+        var latchCreator = ManagedLeaderLatchCreator.start(client, environment, serviceDescriptor, listener);
+
+        assertThat(latchCreator.getHealthCheck()).isPresent();
+        assertThat(latchCreator.getListeners()).hasSize(1).hasOnlyElementsOfTypes(BecameLeaderListener.class);
+
+        verify(healthCheckRegistry).register(eq("leaderLatch"), isA(ManagedLeaderLatchHealthCheck.class));
+        verify(jersey).register(isA(GotLeaderLatchResource.class));
+        verify(jersey).register(isA(LeaderResource.class));
+
+        var leaderLatch = latchCreator.getLeaderLatch();
+        assertStartedAndBecameLeader(leaderLatch, listener);
+    }
+
+    @Slf4j
+    static class BecameLeaderListener implements LeaderLatchListener {
+
+        AtomicBoolean becameLeader = new AtomicBoolean();
+
+        @Override
+        public void isLeader() {
+            boolean result = becameLeader.compareAndSet(false, true);
+            LOG.info("Became leader? {}", result);
+        }
+
+        @Override
+        public void notLeader() {
+            // no-op
+        }
+    }
+
+    private void assertStartedAndBecameLeader(ManagedLeaderLatch leaderLatch, BecameLeaderListener listener) {
+        assertThat(leaderLatch.isStarted()).isTrue();
+        await().atMost(5, TimeUnit.SECONDS).until(() -> listener.becameLeader.get());
+    }
+}

--- a/src/test/java/org/kiwiproject/curator/leader/resource/GotLeaderLatchResourceTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/resource/GotLeaderLatchResourceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class GotLeaderLatchResourceTest {
 
     private static final ResourceExtension RESOURCE = ResourceExtension.builder()
+            .bootstrapLogging(false)
             .addResource(new GotLeaderLatchResource())
             .build();
 

--- a/src/test/java/org/kiwiproject/curator/leader/resource/LeaderResourceTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/resource/LeaderResourceTest.java
@@ -34,6 +34,7 @@ class LeaderResourceTest {
     private static final ManagedLeaderLatch LEADER_LATCH = mock(ManagedLeaderLatch.class);
 
     private static final ResourceExtension RESOURCE = ResourceExtension.builder()
+            .bootstrapLogging(false)
             .addProvider(JaxrsExceptionMapper.class)
             .addProvider(IllegalArgumentExceptionMapper.class)
             .addResource(new LeaderResource(LEADER_LATCH))


### PR DESCRIPTION
* Add ServiceDescriptor value class which contains service metadata
  so we don't need to pass 4 arguments around all over the place
* Add constructor to ManagedLeaderLatch that accepts a ServiceDescriptor
* Add overload of ManagedLeaderLatch#leaderLatchId that accepts
  a ServiceDescriptor instance
* Rename hostName parameter in ManagedLeaderLatch#leaderLatchId
  to hostname for consistency with ServiceDescriptor#hostname
* Add "bootstrapLogging(false)" to the GotLeaderLatchResourceTest
  and LeaderResourceTest to prevent it from hijacking all logging
* Add ManagedLeaderLatchCreator

Fixes #7