### PR TITLE
Update to kiwi-test 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <zookeeper.version>3.4.14</zookeeper.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi.test.version>0.5.0</kiwi.test.version>
+        <kiwi.test.version>0.6.0</kiwi.test.version>
 
     </properties>
 
@@ -224,6 +224,12 @@
             <artifactId>kiwi-test</artifactId>
             <version>${kiwi.test.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.kiwiproject</groupId>
+                    <artifactId>kiwi</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Need to temporarily exclude kiwi version from kiwi-test so that
dependency convergence will pass.