### PR TITLE
Wait until node is deleted in ManagedLeaderLatchCreatorTest

### DIFF
--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
-import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.deleteRecursively;
+import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.deleteRecursivelyIfExists;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -78,7 +78,7 @@ class ManagedLeaderLatchCreatorTest {
     void tearDown() throws Exception {
         var rootPath = "/kiwi/leader-latch";
 
-        deleteRecursively(client, rootPath);
+        deleteRecursivelyIfExists(client, rootPath);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
@@ -81,11 +81,10 @@ class ManagedLeaderLatchCreatorTest {
 
         if (pathExists(rootPath)) {
             LOG.debug("Path {} exists, attempting to delete it", rootPath);
-            client.delete().guaranteed().deletingChildrenIfNeeded().forPath(rootPath);
+            client.delete().deletingChildrenIfNeeded().forPath(rootPath);
 
             // In GitHub we have intermittent test failures caused by NodeExistsException thrown in setUp.
-            // The following attempts to wait and see if it gets deleted. Also, added guaranteed() in the
-            // above code that attempts the deletion, which causes Curator to attempt background deletes.
+            // The following attempts to wait and see if it gets deleted.
             // See issue: https://github.com/kiwiproject/dropwizard-leader-latch/issues/36
             if (pathExists(rootPath)) {
                 LOG.warn("Path {} still exists; wait up to five seconds for it to be deleted", rootPath);

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
@@ -4,7 +4,7 @@ import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.awaitility.Durations.TWO_SECONDS;
+import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
 import static org.mockito.ArgumentMatchers.any;
@@ -88,8 +88,8 @@ class ManagedLeaderLatchCreatorTest {
             // above code that attempts the deletion, which causes Curator to attempt background deletes.
             // See issue: https://github.com/kiwiproject/dropwizard-leader-latch/issues/36
             if (pathExists(rootPath)) {
-                LOG.warn("Path {} still exists; wait up to two seconds for it to be deleted", rootPath);
-                await().atMost(TWO_SECONDS).until(() -> !pathExists(rootPath));
+                LOG.warn("Path {} still exists; wait up to five seconds for it to be deleted", rootPath);
+                await().atMost(FIVE_SECONDS).until(() -> !pathExists(rootPath));
             }
         }
     }

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
@@ -1,12 +1,11 @@
 package org.kiwiproject.curator.leader;
 
-import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
+import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.deleteRecursively;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -79,24 +78,7 @@ class ManagedLeaderLatchCreatorTest {
     void tearDown() throws Exception {
         var rootPath = "/kiwi/leader-latch";
 
-        if (pathExists(rootPath)) {
-            LOG.debug("Path {} exists, attempting to delete it", rootPath);
-            client.delete().deletingChildrenIfNeeded().forPath(rootPath);
-
-            // In GitHub we have intermittent test failures caused by NodeExistsException thrown in setUp.
-            // The following attempts to wait and see if it gets deleted.
-            // See issue: https://github.com/kiwiproject/dropwizard-leader-latch/issues/36
-            if (pathExists(rootPath)) {
-                LOG.warn("Path {} still exists; wait up to five seconds for it to be deleted", rootPath);
-                await().atMost(FIVE_SECONDS).until(() -> !pathExists(rootPath));
-            }
-        }
-    }
-
-    private boolean pathExists(String rootPath) throws Exception {
-        var stat = client.checkExists().forPath(rootPath);
-
-        return nonNull(stat);
+        deleteRecursively(client, rootPath);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.FIVE_SECONDS;
-import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.deleteRecursively;
+import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.deleteRecursivelyIfExists;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
@@ -65,7 +65,7 @@ class ManagedLeaderLatchTest {
         leaderLatch2 = new ManagedLeaderLatch(client, "id-67890", "test-service", leaderListener2);
 
         if (exists(leaderLatch1.getLatchPath())) {
-            deleteRecursively(client, leaderLatch1.getLatchPath());
+            deleteRecursivelyIfExists(client, leaderLatch1.getLatchPath());
         }
     }
 

--- a/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
+++ b/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
@@ -17,7 +17,7 @@ public class CuratorTestHelpers {
             LOG.debug("Path {} exists, attempting to delete it", rootPath);
             client.delete().deletingChildrenIfNeeded().forPath(rootPath);
 
-            // In GitHub we have intermittent test failures caused by NodeExistsException thrown in setUp.
+            // In GitHub we have seen various intermittent test failures caused by NodeExistsException.
             // The following attempts to wait and see if it gets deleted.
             // See issue: https://github.com/kiwiproject/dropwizard-leader-latch/issues/36
             if (pathExists(client, rootPath)) {

--- a/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
+++ b/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
@@ -1,0 +1,35 @@
+package org.kiwiproject.curator.leader.util;
+
+import static java.util.Objects.nonNull;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.FIVE_SECONDS;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+
+@UtilityClass
+@Slf4j
+public class CuratorTestHelpers {
+
+    public static void deleteRecursively(CuratorFramework client, String rootPath) throws Exception {
+        if (pathExists(client, rootPath)) {
+            LOG.debug("Path {} exists, attempting to delete it", rootPath);
+            client.delete().deletingChildrenIfNeeded().forPath(rootPath);
+
+            // In GitHub we have intermittent test failures caused by NodeExistsException thrown in setUp.
+            // The following attempts to wait and see if it gets deleted.
+            // See issue: https://github.com/kiwiproject/dropwizard-leader-latch/issues/36
+            if (pathExists(client, rootPath)) {
+                LOG.warn("Path {} still exists; wait up to five seconds for it to be deleted", rootPath);
+                await().atMost(FIVE_SECONDS).until(() -> !pathExists(client, rootPath));
+            }
+        }
+    }
+
+    public static boolean pathExists(CuratorFramework client, String rootPath) throws Exception {
+        var stat = client.checkExists().forPath(rootPath);
+
+        return nonNull(stat);
+    }
+}


### PR DESCRIPTION
* In tearDown, check if the node still exists after issuing the delete
  operation. If it still exists, wait until it is deleted.

Fixes #36