### PR TITLE
Stop latch ManagedLeaderLatchCreatorTest; add isLeaderLatchStarted()

### DIFF
--- a/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreator.java
+++ b/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreator.java
@@ -3,6 +3,7 @@ package org.kiwiproject.curator.leader;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 
 import io.dropwizard.setup.Environment;
@@ -40,6 +41,7 @@ public class ManagedLeaderLatchCreator {
 
     // Initialized via instance start() method so cannot be final (unless we used Kotlin and lateinit)
     private ManagedLeaderLatch leaderLatch;
+    private boolean latchStarted;
     private boolean addHealthCheck;
     private ManagedLeaderLatchHealthCheck healthCheck;
     private boolean addResources;
@@ -210,6 +212,12 @@ public class ManagedLeaderLatchCreator {
     }
 
     private void startLatchOrThrow() {
+        startLatchOrThrow(leaderLatch);
+        latchStarted = true;
+    }
+
+    static void startLatchOrThrow(ManagedLeaderLatch leaderLatch) {
+        checkArgumentNotNull(leaderLatch);
         try {
             leaderLatch.start();
         } catch (Exception e) {
@@ -232,7 +240,18 @@ public class ManagedLeaderLatchCreator {
     }
 
     /**
+     * Has this instance created and started a {@link ManagedLeaderLatch}?
+     *
+     * @return true if this instance has created and started a leader latch
+     */
+    public boolean isLeaderLatchStarted() {
+        return latchStarted;
+    }
+
+    /**
      * Returns the {@link ManagedLeaderLatch} created after {@link #start()} has been called.
+     * <p>
+     * Use {@link #isLeaderLatchStarted()} to ensure the latch has been started to ensure this method will succeed.
      *
      * @return the leader latch
      * @throws IllegalStateException if called but the latch has not been started yet
@@ -266,6 +285,6 @@ public class ManagedLeaderLatchCreator {
     }
 
     private void validateStarted() {
-        checkState(nonNull(leaderLatch), "Leader latch is not started; call start() first");
+        checkState(latchStarted, "Leader latch is not started; call start() first");
     }
 }

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchTest.java
@@ -1,11 +1,12 @@
 package org.kiwiproject.curator.leader;
 
-import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.FIVE_SECONDS;
+import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.closeIfStarted;
 import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.deleteRecursivelyIfExists;
+import static org.kiwiproject.curator.leader.util.CuratorTestHelpers.startAndAwait;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
@@ -465,26 +466,5 @@ class ManagedLeaderLatchTest {
 
     private Executor nullExecutorWhichShouldNeverBeUsed() {
         return null;
-    }
-
-    private void startAndAwait(ManagedLeaderLatch... latches) throws Exception {
-        for (ManagedLeaderLatch latch : latches) {
-            startAndAwait(latch);
-        }
-    }
-
-    private void startAndAwait(ManagedLeaderLatch latch) throws Exception {
-        latch.start();
-        await().atMost(FIVE_SECONDS).until(latch::isStarted);
-    }
-
-    private void closeIfStarted(ManagedLeaderLatch latch) {
-        if (nonNull(latch) && latch.isStarted()) {
-            LOG.debug("Closing latch {}", latch);
-            latch.stop();
-            await().atMost(FIVE_SECONDS).until(latch::isClosed);
-        } else {
-            LOG.trace("Latch {} not started; ignoring close request", latch);
-        }
     }
 }

--- a/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
+++ b/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
@@ -1,10 +1,13 @@
 package org.kiwiproject.curator.leader.util;
 
 import static java.util.Objects.nonNull;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.FIVE_SECONDS;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
+import org.kiwiproject.curator.leader.ManagedLeaderLatch;
 import org.kiwiproject.retry.SimpleRetryer;
 import org.slf4j.event.Level;
 
@@ -14,15 +17,47 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class CuratorTestHelpers {
 
-    public static void deleteRecursivelyIfExists(CuratorFramework client, String path) throws Exception {
-        if (pathExists(client, path)) {
-            deleteRecursively(client, path);
+    public static void startAndAwait(ManagedLeaderLatch... latches) throws Exception {
+        for (ManagedLeaderLatch latch : latches) {
+            startAndAwait(latch);
         }
     }
 
-    public static void deleteRecursively(CuratorFramework client, String path) {
+    public static void startAndAwait(ManagedLeaderLatch latch) throws Exception {
+        latch.start();
+        await().atMost(FIVE_SECONDS).until(latch::isStarted);
+    }
+
+    public static void closeIfStarted(ManagedLeaderLatch latch) {
+        if (nonNull(latch) && latch.isStarted()) {
+            LOG.debug("Closing latch {}", latch);
+            latch.stop();
+            await().atMost(FIVE_SECONDS).until(latch::isClosed);
+        } else {
+            LOG.trace("Latch {} not started; ignoring close request", latch);
+        }
+    }
+
+    public enum DeleteResult {
+        SUCCEEDED, FAILED, SKIPPED;
+
+        public boolean failed() {
+            return this == FAILED;
+        }
+    }
+
+    public static DeleteResult deleteRecursivelyIfExists(CuratorFramework client, String path) throws Exception {
+        if (pathExists(client, path)) {
+            return deleteRecursively(client, path);
+        }
+
+        return DeleteResult.SKIPPED;
+    }
+
+    public static DeleteResult deleteRecursively(CuratorFramework client, String path) {
         // In GitHub we have seen various intermittent test failures caused by NodeExistsException.
         // See issue: https://github.com/kiwiproject/dropwizard-leader-latch/issues/36
+        // And also: https://github.com/kiwiproject/dropwizard-leader-latch/issues/69
 
         // The following attempts to delete a path and any children. If the path still exists after
         // attempting to delete it, try again up to a max of 5 attempts.
@@ -36,7 +71,7 @@ public class CuratorTestHelpers {
                 .build();
 
         // NOTE: returning null forces a retry unless max attempts have been reached
-        retryer.tryGetObject(() -> {
+        var deletedPathOptional = retryer.tryGetObject(() -> {
             try {
                 deletePathAndChildren(client, path);
 
@@ -46,6 +81,8 @@ public class CuratorTestHelpers {
                 return null;
             }
         });
+
+        return deletedPathOptional.map(thePath -> DeleteResult.SUCCEEDED).orElse(DeleteResult.FAILED);
     }
 
     private static void deletePathAndChildren(CuratorFramework client, String path) throws Exception {


### PR DESCRIPTION
* Add isLeaderLatchStarted() method to ManagedLeaderLatchCreator
* Refactor ManagedLeaderLatchCreator to use a private boolean field
  to track if the latch has been started or not
* Move helper methods from ManagedLeaderLatchTest to CuratorTestHelpers
  to allow calling them from ManagedLeaderLatchCreatorTest
* Update ManagedLeaderLatchCreatorTest to provide more feedback via
  additional logging when things go wrong trying to delete the latch
  znode in ZooKeeper
* While adding the additional logging, noticed that we are not actually
  closing the latch in the tests in ManagedLeaderLatchCreatorTest, so
  maybe (hopefully) this is the reason why we keep seeing the
  intermittent test failures in the GitHub action workflow. To date I
  have yet to have this fail when running locally, but it happens often
  in the CI environment.

Closes #69
Closes #70