### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dropwizard-leader-latch</artifactId>
-    <version>1.0.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,12 +29,12 @@
     <properties>
 
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
-        <kiwi.metrics-healthchecks-severity.version>1.0.13</kiwi.metrics-healthchecks-severity.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
+        <kiwi.metrics-healthchecks-severity.version>2.0.0</kiwi.metrics-healthchecks-severity.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-leader-latch</sonar.projectKey>

--- a/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatch.java
+++ b/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatch.java
@@ -218,7 +218,7 @@ public class ManagedLeaderLatch implements Managed {
      * Returns whether this instance is the leader, or throws a {@link ManagedLeaderLatchException} if Curator is not
      * started yet, this latch is not started yet, or there are no latch participants yet.
      * <p>
-     * The above mentioned situations could happen, for example, because code at startup calls this method before
+     * The above-mentioned situations could happen, for example, because code at startup calls this method before
      * Curator has been started, e.g. before the Jetty server starts in a Dropwizard application, or because the latch
      * does not yet have participants even though Curator and the latch are both started. These restrictions should
      * help prevent false negatives, i.e. having a {@code false} return value but the actual reason was because of

--- a/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreator.java
+++ b/src/main/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreator.java
@@ -6,7 +6,7 @@ import static java.util.Objects.nonNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
@@ -92,7 +92,7 @@ public class ManagedLeaderLatchCreator {
      * check and JAX-RS REST resources) and you do not need references to them, use this method to create and
      * start a latch.
      * <p>
-     * Otherwise use {@link #start(CuratorFramework, Environment, ServiceDescriptor, LeaderLatchListener...)}.
+     * Otherwise, use {@link #start(CuratorFramework, Environment, ServiceDescriptor, LeaderLatchListener...)}.
      *
      * @param client            the Curator client
      * @param environment       the Dropwizard environment

--- a/src/main/java/org/kiwiproject/curator/leader/health/ManagedLeaderLatchHealthCheck.java
+++ b/src/main/java/org/kiwiproject/curator/leader/health/ManagedLeaderLatchHealthCheck.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.curator.leader.health;
 
-import static java.util.stream.Collectors.toList;
 import static org.kiwiproject.collect.KiwiLists.isNullOrEmpty;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newHealthyResultBuilder;
 import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResultBuilder;
@@ -74,13 +73,13 @@ public class ManagedLeaderLatchHealthCheck extends HealthCheck {
         return participants.stream()
                 .filter(Participant::isLeader)
                 .map(Participant::getId)
-                .collect(toList());
+                .toList();
     }
 
     private static List<String> idsOf(Collection<Participant> participants) {
         return participants.stream()
                 .map(Participant::getId)
-                .collect(toList());
+                .toList();
     }
 
 }

--- a/src/main/java/org/kiwiproject/curator/leader/resource/GotLeaderLatchResource.java
+++ b/src/main/java/org/kiwiproject/curator/leader/resource/GotLeaderLatchResource.java
@@ -1,10 +1,10 @@
 package org.kiwiproject.curator.leader.resource;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 /**
  * JAX-RS resource providing a single endpoint that allows clients to determine whether this service

--- a/src/main/java/org/kiwiproject/curator/leader/resource/LeaderResource.java
+++ b/src/main/java/org/kiwiproject/curator/leader/resource/LeaderResource.java
@@ -1,12 +1,12 @@
 package org.kiwiproject.curator.leader.resource;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.kiwiproject.curator.leader.ManagedLeaderLatch;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.Map;
 
 /**

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
@@ -20,10 +20,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;

--- a/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
+++ b/src/test/java/org/kiwiproject/curator/leader/util/CuratorTestHelpers.java
@@ -55,7 +55,7 @@ public class CuratorTestHelpers {
     }
 
     public static DeleteResult deleteRecursively(CuratorFramework client, String path) {
-        // In GitHub we have seen various intermittent test failures caused by NodeExistsException.
+        // In GitHub, we have seen various intermittent test failures caused by NodeExistsException.
         // See issue: https://github.com/kiwiproject/dropwizard-leader-latch/issues/36
         // And also: https://github.com/kiwiproject/dropwizard-leader-latch/issues/69
 


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9