### PR TITLE
Add new methods to ManagedLeaderLatch for checking leadership

### DIFF
--- a/src/main/java/org/kiwiproject/curator/leader/LeadershipStatus.java
+++ b/src/main/java/org/kiwiproject/curator/leader/LeadershipStatus.java
@@ -1,0 +1,118 @@
+package org.kiwiproject.curator.leader;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+
+/**
+ * Defines a type that can be returned when checking if a {@link LeaderLatch}
+ * has leadership, taking into account the various issues that can cause problems.
+ * <p>
+ * There are two sub-interfaces, {@link ValidLeadershipStatus} and
+ * {@link ErrorLeadershipStatus}, each of which has several {@code record} implementations.
+ * This allows you to determine whether the return value is a valid status or if
+ * there is some kind of error.
+ */
+public sealed interface LeadershipStatus {
+
+    /**
+     * Check whether the status is from a valid state, where the
+     * Curator client and the {@code LeaderLatch} are both started, and there
+     * are latch participants.
+     *
+     * @return true if the leadership status is from a valid latch,
+     * otherwise false
+     */
+    default boolean isValidStatus() {
+        return !isErrorStatus();
+    }
+
+    /**
+     * Check whether the status is from a bad latch state, where
+     * the Curator client or the {@code LeaderLatch} might not be started
+     * or there are no participants in the latch.
+     *
+     * @return true if the leadership status is from an invalid latch state,
+     * otherwise false
+     */
+    boolean isErrorStatus();
+
+    /**
+     * Defines a valid leadership status.
+     */
+    sealed interface ValidLeadershipStatus extends LeadershipStatus
+            permits IsLeader, NotLeader {
+
+        @Override
+        default boolean isErrorStatus() {
+            return false;
+        }
+    }
+
+    /**
+     * Defines an invalid leadership status caused by an error or erroneous state.
+     */
+    sealed interface ErrorLeadershipStatus extends LeadershipStatus
+            permits CuratorNotStarted, LatchNotStarted, NoLatchParticipants, OtherError {
+
+        @Override
+        default boolean isErrorStatus() {
+            return true;
+        }
+    }
+
+    /**
+     * Represents a valid latch state, where the participant is the current leader.
+     */
+    record IsLeader() implements ValidLeadershipStatus {}
+
+    /**
+     * Represents a valid latch state, where the participant is not the leader.
+     */
+    record NotLeader() implements ValidLeadershipStatus {}
+
+    /**
+     * Represents an invalid latch state; Curator is not in the
+     * {@link CuratorFrameworkState#STARTED STARTED} state.
+     *
+     * @param curatorState the Curator state
+     */
+    record CuratorNotStarted(CuratorFrameworkState curatorState) implements ErrorLeadershipStatus {
+        public CuratorNotStarted {
+            checkArgument(nonNull(curatorState) && curatorState != CuratorFrameworkState.STARTED,
+                    "curatorState must not be null or STARTED");
+        }
+    }
+
+    /**
+     * Represents an invalid latch state; the LeaderLatch is not in the
+     * {@link LeaderLatch.State#STARTED STARTED} state.
+     *
+     * @param latchState the {@code LeaderLatch} state
+     */
+    record LatchNotStarted(LeaderLatch.State latchState) implements ErrorLeadershipStatus {
+        public LatchNotStarted {
+            checkArgument(nonNull(latchState) && latchState != LeaderLatch.State.STARTED,
+                    "latchState must not be null or STARTED");
+        }
+    }
+
+    /**
+     * Represents an invalid latch state; the {@code LeaderLatch} has no participants.
+     */
+    record NoLatchParticipants() implements ErrorLeadershipStatus {}
+
+    /**
+     * Represents an invalid latch state; an unexpected Exception was thrown.
+     *
+     * @param error the exception that was thrown checking leadership status
+     */
+    record OtherError(Exception error) implements ErrorLeadershipStatus {
+        public OtherError {
+            checkArgumentNotNull(error, "error must not be null");
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/curator/leader/LeadershipStatusTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/LeadershipStatusTest.java
@@ -1,0 +1,86 @@
+package org.kiwiproject.curator.leader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.kiwiproject.curator.leader.LeadershipStatus.CuratorNotStarted;
+import org.kiwiproject.curator.leader.LeadershipStatus.IsLeader;
+import org.kiwiproject.curator.leader.LeadershipStatus.LatchNotStarted;
+import org.kiwiproject.curator.leader.LeadershipStatus.NoLatchParticipants;
+import org.kiwiproject.curator.leader.LeadershipStatus.NotLeader;
+import org.kiwiproject.curator.leader.LeadershipStatus.OtherError;
+
+@DisplayName("LeadershipStatus")
+class LeadershipStatusTest {
+
+    @Test
+    void shouldCheckIsValidStatus() {
+        assertAll(
+                () -> assertThat(new IsLeader().isValidStatus()).isTrue(),
+                () -> assertThat(new NotLeader().isValidStatus()).isTrue(),
+                () -> assertThat(new CuratorNotStarted(CuratorFrameworkState.LATENT).isValidStatus()).isFalse(),
+                () -> assertThat(new LatchNotStarted(LeaderLatch.State.CLOSED).isValidStatus()).isFalse(),
+                () -> assertThat(new NoLatchParticipants().isValidStatus()).isFalse(),
+                () -> assertThat(new OtherError(new KeeperException.NoNodeException("/latch/path")).isValidStatus()).isFalse()
+        );
+    }
+
+    @Test
+    void shouldCheckIsErrorStatus() {
+        assertAll(
+                () -> assertThat(new IsLeader().isErrorStatus()).isFalse(),
+                () -> assertThat(new NotLeader().isErrorStatus()).isFalse(),
+                () -> assertThat(new CuratorNotStarted(CuratorFrameworkState.STOPPED).isErrorStatus()).isTrue(),
+                () -> assertThat(new LatchNotStarted(LeaderLatch.State.LATENT).isErrorStatus()).isTrue(),
+                () -> assertThat(new NoLatchParticipants().isErrorStatus()).isTrue(),
+                () -> assertThat(new OtherError(new KeeperException.NoNodeException("/latch/path")).isErrorStatus()).isTrue()
+        );
+    }
+
+    @Nested
+    class CuratorNotStartedRecord {
+
+        @ParameterizedTest
+        @NullSource
+        @EnumSource(value = CuratorFrameworkState.class, names = { "STARTED" })
+        void shouldNotAllowNullOrStartedState(CuratorFrameworkState curatorState) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new CuratorNotStarted(curatorState));
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = CuratorFrameworkState.class, names = { "STARTED" }, mode = EnumSource.Mode.EXCLUDE)
+        void shouldAcceptValidStates(CuratorFrameworkState curatorState) {
+            assertThatCode(() -> new CuratorNotStarted(curatorState)).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class LatchNotStartedRecord {
+
+        @ParameterizedTest
+        @NullSource
+        @EnumSource(value = LeaderLatch.State.class, names = { "STARTED" })
+        void shouldNotAllowNullOrStartedState(LeaderLatch.State latchState) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new LatchNotStarted(latchState));
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = LeaderLatch.State.class, names = { "STARTED" }, mode = EnumSource.Mode.EXCLUDE)
+        void shouldAcceptValidStates(LeaderLatch.State latchState) {
+            assertThatCode(() -> new LatchNotStarted(latchState)).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
+++ b/src/test/java/org/kiwiproject/curator/leader/ManagedLeaderLatchCreatorTest.java
@@ -318,7 +318,7 @@ class ManagedLeaderLatchCreatorTest {
     @Slf4j
     static class BecameLeaderListener implements LeaderLatchListener {
 
-        AtomicBoolean becameLeader = new AtomicBoolean();
+        final AtomicBoolean becameLeader = new AtomicBoolean();
 
         @Override
         public void isLeader() {
@@ -334,6 +334,6 @@ class ManagedLeaderLatchCreatorTest {
 
     private void assertStartedAndBecameLeader(ManagedLeaderLatch leaderLatch, BecameLeaderListener listener) {
         assertThat(leaderLatch.isStarted()).isTrue();
-        await().atMost(5, TimeUnit.SECONDS).until(() -> listener.becameLeader.get());
+        await().atMost(5, TimeUnit.SECONDS).until(listener.becameLeader::get);
     }
 }


### PR DESCRIPTION
* Add getManagedLatch "escape hatch" method to return the managed Curator LeaderLatch.
* Add hasLeadershipIgnoringErrors to ManagedLeaderLatch; it ignores errors and invalid states, and returns a boolean.
* Add checkLeadershipStatus method to ManagedLeaderLatch; it returns a class that represents the exact state of the managed LeaderLatch, including valid and invalid states, and errors.
* Add LeadershipStatus sealed interface with implementations that cover valid (leader/not leader) and invalid states, and any errors that might occur checking leadership.
* Fix a few grammatical errors in ManagedLeaderLatch docs.
* Minor code cleanup in ManagedLeaderLatchCreatorTest.

Closes #280
Closes #286