### PR TITLE
Add cooldown periods to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
       - "sleberknight"
       - "chrisrohr"
     open-pull-requests-limit: 10
+    cooldown:
+      semver-patch-days: 5
+      semver-minor-days: 14
+      semver-major-days: 30
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Add cooldown periods to the Dependabot configuration to reduce noise from immediate version bump PRs. This gives time for issues with new releases to surface in the community before we adopt them. Patch: 5 days, minor: 14 days, major: 30 days.